### PR TITLE
Enable orders screen navigation

### DIFF
--- a/app/src/main/java/br/com/neto/orlando/buymore/navigation/AppNavigation.kt
+++ b/app/src/main/java/br/com/neto/orlando/buymore/navigation/AppNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import br.com.neto.orlando.buymore.ui.screen.CustomerRegistration
+import br.com.neto.orlando.buymore.ui.screen.SalesListScreen
 import br.com.neto.orlando.buymore.ui.screen.StartMenu
 
 @Composable
@@ -26,10 +27,22 @@ fun AppNavigation() {
         }
 
         composable("startMenu") {//tela de login
-            StartMenu(onRegisterCustomer = {
-                navController.navigate("customerRegistration")
-            })
+            StartMenu(
+                onRegisterCustomer = {
+                    navController.navigate("customerRegistration")
+                },
+                onSalesList = {
+                    navController.navigate("salesList")
+                }
+            )
         }
+        composable("salesList") {
+            BackHandler {
+                navController.popBackStack()
+            }
+            SalesListScreen()
+        }
+
         composable("customerRegistration") {//tela de cadastro de cliente
             BackHandler {
                 Log.d("BackHandler", "Voltar pressionado!")

--- a/app/src/main/java/br/com/neto/orlando/buymore/ui/screen/StartMenu.kt
+++ b/app/src/main/java/br/com/neto/orlando/buymore/ui/screen/StartMenu.kt
@@ -39,7 +39,10 @@ import br.com.neto.orlando.buymore.ui.theme.MyLightGray
 import br.com.neto.orlando.buymore.ui.theme.Orange
 
 @Composable
-fun StartMenu(onRegisterCustomer: () -> Unit) {
+fun StartMenu(
+    onRegisterCustomer: () -> Unit,
+    onSalesList: () -> Unit
+) {
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MyLightGray
@@ -61,8 +64,8 @@ fun StartMenu(onRegisterCustomer: () -> Unit) {
                     title = "Pedido",
                     description = "Toque ou deslize",
                     icon = Icons.Default.ShoppingCart,
-                    onClick = { },
-                    onSwipe = { }
+                    onClick = { onSalesList() },
+                    onSwipe = { onSalesList() }
                 )
 
                 SwipeableMenuCard(
@@ -146,5 +149,5 @@ fun SwipeableMenuCard(
 @Preview
 @Composable
 private fun StartMenuPrev() {
-    StartMenu(onRegisterCustomer = {})
+    StartMenu(onRegisterCustomer = {}, onSalesList = {})
 }


### PR DESCRIPTION
## Summary
- allow StartMenu to navigate to the SalesListScreen via onSalesList callback
- wire salesList route into AppNavigation

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684b7a364a048322a0960d3ae12a3cde