### PR TITLE
Add Products card on start menu

### DIFF
--- a/app/src/main/java/br/com/neto/orlando/buymore/navigation/AppNavigation.kt
+++ b/app/src/main/java/br/com/neto/orlando/buymore/navigation/AppNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import br.com.neto.orlando.buymore.ui.screen.CustomerRegistration
 import br.com.neto.orlando.buymore.ui.screen.SalesListScreen
+import br.com.neto.orlando.buymore.ui.screen.ProductsListScreen
 import br.com.neto.orlando.buymore.ui.screen.StartMenu
 
 @Composable
@@ -33,6 +34,9 @@ fun AppNavigation() {
                 },
                 onSalesList = {
                     navController.navigate("salesList")
+                },
+                onProductsList = {
+                    navController.navigate("productList")
                 }
             )
         }
@@ -49,6 +53,13 @@ fun AppNavigation() {
                 navController.popBackStack()
             }
             CustomerRegistration()
+        }
+
+        composable("productList") {
+            BackHandler {
+                navController.popBackStack()
+            }
+            ProductsListScreen()
         }
     }
 }

--- a/app/src/main/java/br/com/neto/orlando/buymore/ui/screen/ProductsListScreen.kt
+++ b/app/src/main/java/br/com/neto/orlando/buymore/ui/screen/ProductsListScreen.kt
@@ -1,0 +1,28 @@
+package br.com.neto.orlando.buymore.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
+import br.com.neto.orlando.buymore.ui.theme.MyDarkGray
+import br.com.neto.orlando.buymore.ui.theme.Orange
+
+@Composable
+fun ProductsListScreen() {
+    Surface(modifier = Modifier.fillMaxSize(), color = MyDarkGray) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(text = "Produtos", color = Orange, fontSize = 32.sp)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProductsListScreenPreview() {
+    ProductsListScreen()
+}

--- a/app/src/main/java/br/com/neto/orlando/buymore/ui/screen/StartMenu.kt
+++ b/app/src/main/java/br/com/neto/orlando/buymore/ui/screen/StartMenu.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.Store
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -41,7 +42,8 @@ import br.com.neto.orlando.buymore.ui.theme.Orange
 @Composable
 fun StartMenu(
     onRegisterCustomer: () -> Unit,
-    onSalesList: () -> Unit
+    onSalesList: () -> Unit,
+    onProductsList: () -> Unit
 ) {
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -74,6 +76,14 @@ fun StartMenu(
                     icon = Icons.Default.Person,
                     onClick = { onRegisterCustomer()},
                     onSwipe = { onRegisterCustomer()}
+                )
+
+                SwipeableMenuCard(
+                    title = "Produtos",
+                    description = "Toque ou deslize",
+                    icon = Icons.Default.Store,
+                    onClick = { onProductsList() },
+                    onSwipe = { onProductsList() }
                 )
             }
 
@@ -149,5 +159,5 @@ fun SwipeableMenuCard(
 @Preview
 @Composable
 private fun StartMenuPrev() {
-    StartMenu(onRegisterCustomer = {}, onSalesList = {})
+    StartMenu(onRegisterCustomer = {}, onSalesList = {}, onProductsList = {})
 }


### PR DESCRIPTION
## Summary
- add ProductsListScreen placeholder
- add Products card with store icon in StartMenu
- handle Products card navigation in AppNavigation

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684b7c9bd638832283ab7388372275b2